### PR TITLE
Docs? Who needs those...

### DIFF
--- a/.github/ISSUE_TEMPLATE/Resolution_proposal.md
+++ b/.github/ISSUE_TEMPLATE/Resolution_proposal.md
@@ -1,3 +1,11 @@
+---
+name: Resolution Proposal
+about: Put forward a proposal for a resolution to be considered at a Foundation Session
+title: ''
+labels: 'agenda-item-proposed'
+assignees: 'corbob'
+
+---
 <!--
 The suggested workflow of a resolution proposal is as follows:
 


### PR DESCRIPTION
Looking at what's actually done in other repos, was missing the frontmatter.

This should automatically tag these issues as `agenda-item-proposes` and assign them to me 🤷‍♂️